### PR TITLE
Ditch timeouts for sync tasks.

### DIFF
--- a/lib/task_flow/tasks/async_task.rb
+++ b/lib/task_flow/tasks/async_task.rb
@@ -1,7 +1,9 @@
 # encoding: utf-8
 module TaskFlow
   class AsyncTask < Task
-    cattr_accessor(:default_options) { { timeout: 1 } }
+    def initialize(name, dependencies, connections, options, block)
+      super(name, dependencies, connections, options.merge(timeout: 1), block)
+    end
 
     def result(registry = nil)
       value(options[:timeout])

--- a/lib/task_flow/tasks/sync_task.rb
+++ b/lib/task_flow/tasks/sync_task.rb
@@ -7,30 +7,13 @@ module TaskFlow
       instrument("#{name}.results.task_flow") do
         return value unless dependencies.any?
 
-        timeouts = registry.cumulative_timeout(name)
-        if event.wait(timeouts)
-          value
-        else
-          reasons = registry.dependency_states(name).map do |name, state|
-            case state
-            when :pending then "\t#{name} never finished"
-            when :unscheduled then "\t#{name} never started"
-            end
-          end
-          fail Timeout::Error, "#{name} result timed out because:\n#{reasons.compact.join("\n")}"
-        end
+        timeout = registry.cumulative_timeout(name)
+        value(timeout)
       end
     end
 
     def task_class
       Present
-    end
-
-    def dependency_observer
-      @dependency_observer ||= Concurrent::DependencyCounter.new(dependencies.size) do
-        task.execute
-        event.set
-      end
     end
   end
 end


### PR DESCRIPTION
Each call to timeout method creates a new thread and executes the block
on that thread. This is unneccessary because async tasks already execute
on a thread pool thread and handle timeouts and sync tasks are not
interrupted when timeout elapses anyway. One should not use a sync task
for a long running task.
